### PR TITLE
Complete refactor of exceptions.

### DIFF
--- a/pyproven/exceptions.py
+++ b/pyproven/exceptions.py
@@ -1,61 +1,27 @@
-from typing import Any, Dict, Optional
-import pymongo
+from typing import List
 
 from pymongo.errors import PyMongoError
 
 
-class PyProvenError(Exception):
+def extract_error_info(err: PyMongoError):
+    """Attempts to extract error fields from the Pymongo document."""
+    error_doc: List[str] = err._message.split("{")[1].split("}")[0].split(",")
+    ok: int = int(error_doc[0].split(": ")[1])
+    errmsg: str = error_doc[1].split(": ")[1].lstrip('"').rstrip('"')
+    code: int = int(error_doc[2].split(": ")[1])
+    codeName: str = error_doc[3].split(": ")[1].lstrip('"').rstrip('"')
+    return {"ok": ok, "errmsg": errmsg, "code": code, "codeName": codeName}
+
+
+class PyProvenError(PyMongoError):
     """Base class for all pyproven exceptions."""
 
-    def __init__(
-        self,
-        message: str = "",
-        pymongo_exception: Optional[PyMongoError] = None,
-    ):
-        self.message = message
-        self.mongo_excep = pymongo_exception
-        self.explain = self.message 
-        if self.mongo_excep:
-            self.explain += (
-                f" \n pymongo also raised an exception: {str(self.mongo_excep)}. \n"
-            )
-        super().__init__(self.explain)
+    def __init__(self, err: PyMongoError):
+        super().__init__(message=err._message, error_labels=err._error_labels)
 
 
-class DocumentHistoryError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB` fails to gather document history."""
-
-
-class SetVersionError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB` is unable to set db version."""
-
-
-class GetVersionError(PyProvenError):
-    """Exception raised when :class:pyproven.database.ProvenDB' is unable to retrieve current version of database."""
-
-
-class ListVersionError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB` is unable to retrieve the version list of database."""
-
-
-class BulkLoadError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB` fails to set or get bulk load status."""
-
-
-class BulkLoadStartError(BulkLoadError):
-    """Generic exception when failing to set the db to start bulk loading. """
-
-
-class BulkLoadAlreadyStartedError(BulkLoadError):
+class BulkLoadAlreadyStartedError(PyProvenError):
     """Exception raised when a command to start bulk loading is sent, but bulk loading has already started."""
-
-
-class BulkLoadStopError(BulkLoadError):
-    """Generic exception raised when failing to set db to stop bulk loading."""
-
-
-class BulkLoadNotStartedError(BulkLoadError):
-    """Exception raised when attempting to stop/kill bulk loading on a db, but the db is not currently bulk loading."""
 
 
 class CompactError(PyProvenError):
@@ -63,51 +29,9 @@ class CompactError(PyProvenError):
     fails to compact between two versions."""
 
 
-class CreateIgnoredError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB`
-    fails to set a collection to be ignored."""
+class CompactValueError(CompactError):
+    """Error raised when versions given for compacting are invalid."""
 
 
-class PrepareForgetError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB`
-    fails to prepare a set of documents to be forgotten."""
-
-
-class ExecuteForgetError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB`
-    fails to forget a set of documents."""
-
-
-class GetDocumentProofError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB`
-    fails to get the proofs of a certain set of documents.
-    This is only raised when the command fails, if individual documents are invalid,
-    the errors will be contained within the response proofs."""
-
-
-class GetVersionProofError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB` fails to get the proof document for a specific version. """
-
-
-class RollbackError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB` fails to rollback the database to the last valid version."""
-
-
-class ListStorageError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB`fails to get the list of storage sizes for each collection in the db. """
-
-
-class SubmitProofError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB` fails at submitting a proof. """
-
-
-class VerifyProofError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB` fails at varifying a proof. """
-
-
-class ShowMetadataError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB` fails at displaying metadata."""
-
-
-class HideMetadataError(PyProvenError):
-    """Exception raised when :class:`pyproven.database.ProvenDB` fails at hiding metadata."""
+class CompactProofError(CompactError):
+    """Error raised when a proof doesn't exist above the compact range."""

--- a/tests/db_tests.py
+++ b/tests/db_tests.py
@@ -1,3 +1,4 @@
+from pymongo.errors import PyMongoError
 from pyproven.storage import ListStorageResponse
 from typing import List
 
@@ -7,7 +8,6 @@ import os
 
 from pymongo import MongoClient
 
-from pyproven.exceptions import BulkLoadError, SetVersionError
 from pyproven import ProvenDB
 
 import time
@@ -41,10 +41,7 @@ class ProvenDBTests(unittest.TestCase):
             status = self.pdb.bulk_load_status()
             self.assertTrue(status.status == "off")
         except Exception as err:
-            try:
-                self.pdb.bulk_load_kill()
-            except BulkLoadError:
-                pass
+            self.pdb.bulk_load_kill()
             raise err
     def test_get_version(self):
         """PyProven can get the version the DB is set to."""
@@ -65,7 +62,7 @@ class ProvenDBTests(unittest.TestCase):
         """PyProven will raise the correct exception when given an impossible version number."""
         version = self.pdb.set_version("current")
         impossible_version = version.version + 1000
-        with self.assertRaises(SetVersionError):
+        with self.assertRaises(PyMongoError):
             self.pdb.set_version(impossible_version)
 
     def test_list_versions_noargs(self):


### PR DESCRIPTION
PyProven now only raises exceptions for specific events, and errors are now inheiriting from PyMongoErrors, rather than being wrappers for the underlying exception. 